### PR TITLE
Try asking composer for the configured bindir

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -286,12 +286,12 @@ export class PhpStanController {
   }
 
   protected makeCommandPath(cwd: string) {
-    let binary = "";
-    if (process.platform === "win32") {
-      binary = path.resolve(cwd, "vendor/bin/phpstan.bat");
-    } else {
-      binary = path.resolve(cwd, "vendor/bin/phpstan");
-    }
+    let bindir = "vendor/bin";
+    const basename = process.platform === "win32" ? "phpstan.bat" : "phpstan";
+    try {
+      bindir = child_process.execSync("composer config bin-dir", {cwd}).toString().trim();
+    } catch (err) {}
+    const binary = path.resolve(cwd, bindir, basename);
     try {
       fs.accessSync(binary, fs.constants.X_OK);
       return binary;


### PR DESCRIPTION
This makes the extension work with composer configurations that override the default bin-dir like this:
```json
{
    "config": {
        "bin-dir": "bin"
    },
    ...
}
```

Without this fix, I could not make the extension work in any way other than specifying an explicit path to phpstan.

An alternative approach would be to search for phpstan in `vendor/phpstan/phpstan/bin/phpstan` which is always present no matter the composer settings but it would fail when using a different package (not sure how likely that would be)...