### PR TITLE
Support custom executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This extension contributes the following settings:
 * `phpstan.memoryLimit`: memory limit, default 512M
 * `phpstan.configuration`: path of configuration
 * `phpstan.autoloadFile`: path of autoload file
+* `phpstan.binPath`: path to the phpstan executable, default phpstan
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
             "type": "string",
             "default": null,
             "description": "PhpStan autoload-file path"
+          },
+          "phpstan.binPath": {
+            "type": "string",
+            "default": "phpstan",
+            "description": "Path to phpstan executable"
           }
         }
       }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -283,7 +283,8 @@ export class PhpStanController {
     });
   }
 
-  protected makeCommandPath(cwd: string, binary: string) {
+  protected makeCommandPath(cwd: string, binary?: string) {
+    const binary = binary ? "phpstan" : binary ;
     try {
       fs.accessSync(binary, fs.constants.X_OK);
       return binary;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -247,7 +247,7 @@ export class PhpStanController {
     }
 
     let phpstan = child_process.spawn(
-      this.makeCommandPath(cwd),
+      this.makeCommandPath(cwd, args.binPath),
       this.makeCommandArgs(args),
       this.setCommandOptions(cwd)
     );
@@ -283,8 +283,7 @@ export class PhpStanController {
     });
   }
 
-  protected makeCommandPath(cwd: string) {
-    const binary = this._config.binPath;
+  protected makeCommandPath(cwd: string, binary: string) {
     try {
       fs.accessSync(binary, fs.constants.X_OK);
       return binary;


### PR DESCRIPTION
This will allow using docker container for running phpstan eg.

```"phpstan.binPath": "docker-compose exec [container] phpstan"```

It removes phpstan.bat and all references to platform detection. User will have to provide binPath if it's different then `phpstan` (not installed globally)