### PR TITLE
Prevent errors from disappearing during analysis

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -224,7 +224,6 @@ export class PhpStanController {
     let basedir: string = "";
     if (stats.isFile()) {
       basedir = path.dirname(the_path);
-      this._diagnosticCollection.delete(Uri.file(the_path));
     } else if (stats.isDirectory()) {
       basedir = the_path;
     } else {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -261,6 +261,10 @@ export class PhpStanController {
       this._analyzing = false;
       this._statusBarItem.show();
 
+      if (stats.isFile()) {
+        this._diagnosticCollection.delete(Uri.file(the_path));
+      }
+
       if (code === 0) {
         // no error
         this._statusBarItem.text = "[phpstan] passed";


### PR DESCRIPTION
The deletion of old diagnostics was moved after the phpstan process exits.

Fixes #15 